### PR TITLE
Character scale when changing stepper value

### DIFF
--- a/source/editors/CharacterEditorState.hx
+++ b/source/editors/CharacterEditorState.hx
@@ -771,9 +771,9 @@ class CharacterEditorState extends MusicBeatState
 			{
 				reloadCharacterImage();
 				char.jsonScale = sender.value;
-				char.setGraphicSize(Std.int(char.width * char.jsonScale));
+				char.scale.set(char.jsonScale, char.jsonScale);
 				char.updateHitbox();
-				ghostChar.setGraphicSize(Std.int(ghostChar.width * char.jsonScale));
+				ghostChar.scale.set(char.jsonScale, char.jsonScale);
 				ghostChar.updateHitbox();
 				reloadGhost();
 				updatePointerPos();


### PR DESCRIPTION
Before, it scaled relative to its current scale, instead of setting it to the right number.